### PR TITLE
attrs variable does not exist. Sending options instead.

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,7 +94,7 @@ module Pipedrive
           end
           data
         else
-          bad_response(res,attrs)
+          bad_response(res,options)
         end
       end
 


### PR DESCRIPTION
Avoid throw errors each time it gets a bad response. It's just blowing errors over rollbar.
