### PR TITLE
attrs doesn't exist, using options instead

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,7 +94,7 @@ module Pipedrive
           end
           data
         else
-          bad_response(res,attrs)
+          bad_response(res,options)
         end
       end
 


### PR DESCRIPTION
It's just blowing a lot of errors when instead of return the bad_response because the variable doesn't exist in the scope.

I did not add tests because my environment is not compatible now. Just to avoid throw `undefined method or local variable attrs` for class.
